### PR TITLE
derive Default, Copy for BoundBox. impl BoundBoxTrait for Rect

### DIFF
--- a/layout21raw/src/bbox.rs
+++ b/layout21raw/src/bbox.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 // Local imports
 use crate::{
     geom::{Point, Shape},
-    Int,
+    Int, Rect,
 };
 
 /// # Axis-Aligned Rectangular Bounding Box
@@ -17,7 +17,7 @@ use crate::{
 /// `p0` is always closest to negative-infinity, in both x and y,
 /// and `p1` is always closest to positive-infinity.
 ///
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Default, Copy, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct BoundBox {
     pub p0: Point,
     pub p1: Point,
@@ -130,7 +130,7 @@ impl BoundBoxTrait for Point {
         if !bbox.contains(self) {
             return BoundBox::empty();
         }
-        bbox.intersection(&BoundBox::from_point(self)) 
+        bbox.intersection(&BoundBox::from_point(self))
     }
     fn union(&self, bbox: &BoundBox) -> BoundBox {
         BoundBox::new(
@@ -149,6 +149,13 @@ impl BoundBoxTrait for Shape {
         }
     }
 }
+
+impl BoundBoxTrait for Rect {
+    fn bbox(&self) -> BoundBox {
+        BoundBox::from_points(&self.p0, &self.p1)
+    }
+}
+
 impl BoundBoxTrait for Vec<Point> {
     fn bbox(&self) -> BoundBox {
         // Take the union of all points in the vector

--- a/layout21raw/src/geom.rs
+++ b/layout21raw/src/geom.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::{bbox::BoundBoxTrait, Int};
 
 /// # Point in two-dimensional layout-space
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Point {
     pub x: Int,
     pub y: Int,
@@ -95,7 +95,7 @@ impl std::ops::Not for Dir {
 /// Open-ended geometric path with non-zero width.
 /// Primarily consists of a series of ordered [Point]s.
 ///
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Path {
     pub points: Vec<Point>,
     pub width: usize,
@@ -108,7 +108,7 @@ pub struct Path {
 /// Closure from the last point back to the first is implied;
 /// the initial point need not be repeated at the end.
 ///
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Polygon {
     pub points: Vec<Point>,
 }
@@ -116,7 +116,7 @@ pub struct Polygon {
 ///
 /// Axis-aligned rectangle, specified by two opposite corners.
 ///
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Rect {
     pub p0: Point,
     pub p1: Point,


### PR DESCRIPTION
Hey Dan,

I needed the ability to clone some layout21raw structs and derive default for my wrapper structs of some layout21raw structs so I made these modifications to a local copy of the Layout21 repo. I also added implemented BoundBoxTrait for Rect because this made the ergonomics of my code better. I think the other change I made was deriving Copy for a couple of structs that contain only Copy fields.

Would it be useful for me to go through the rest of the type definitions in layout21 raw and add derives for Copy, Clone, Default and Debug where they are missing?