### PR TITLE
skip erroneous structs in GDS export instead of dying

### DIFF
--- a/layout21raw/src/gds.rs
+++ b/layout21raw/src/gds.rs
@@ -83,7 +83,13 @@ impl<'lib> GdsExporter<'lib> {
         // And convert each of our `cells` into its `structs`
         for cell in self.lib.cells.iter() {
             let cell = cell.read()?;
-            let strukt = self.export_cell(&*cell)?;
+            let strukt = match self.export_cell(&*cell) {
+                Ok(strukt) => strukt,
+                Err(err) => {
+                    println!("Skipping export, {:?}", err);
+                    continue;
+                }
+            };
             gdslib.structs.push(strukt);
         }
         self.ctx.pop();


### PR DESCRIPTION
Currently, including an external module as a `vlsir.raw.Cell` which defines only a circuit `vlsir.circuit.Module` and no layout `vlsir.raw.Layout` is an error that breaks the GDS exporter. This change skips erroneous structs on export but still dumps the error to the user.