### PR TITLE
Export the shape data from the AbstractPort

### DIFF
--- a/layout21raw/src/proto.rs
+++ b/layout21raw/src/proto.rs
@@ -135,6 +135,7 @@ impl<'lib> ProtoExporter<'lib> {
             for shape in shapes.iter() {
                 self.export_and_add_shape(shape, &mut pshapes)?;
             }
+            pport.shapes.push(pshapes);
         }
         Ok(pport)
     }


### PR DESCRIPTION
We were collecting the port shapes from the original AbstractPort but not adding them to the new protobuf structure.