### PR TITLE
LEF additions for library and macro level

### DIFF
--- a/lef21/resources/lef21.schema.json
+++ b/lef21/resources/lef21.schema.json
@@ -3,6 +3,9 @@
   "title": "Lef Library",
   "description": "LEF's primary design-content container, including a set of macro/cell definitions and associated metadata.",
   "type": "object",
+  "required": [
+    "fixed_mask"
+  ],
   "properties": {
     "bus_bit_chars": {
       "description": "Bus-Bit Separator Characters",
@@ -27,10 +30,9 @@
     },
     "clearance_measure": {
       "description": "Clearance Measure",
-      "writeOnly": true,
       "anyOf": [
         {
-          "$ref": "#/definitions/Unsupported"
+          "$ref": "#/definitions/LefClearanceStyle"
         },
         {
           "type": "null"
@@ -47,16 +49,15 @@
       "minLength": 1
     },
     "extensions": {
-      "description": "Syntax Extensions (Unsupported)",
+      "description": "Syntax Extensions",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/LefExtension"
+      }
+    },
+    "fixed_mask": {
       "writeOnly": true,
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Unsupported"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": "boolean"
     },
     "layers": {
       "description": "Layer Definitions",
@@ -79,15 +80,11 @@
     },
     "manufacturing_grid": {
       "description": "Manufacturing Grid",
-      "writeOnly": true,
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Unsupported"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
     },
     "max_via_stack": {
       "description": "Max Via Stack",
@@ -137,15 +134,10 @@
     },
     "property_definitions": {
       "description": "Property Definitions",
-      "writeOnly": true,
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Unsupported"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/LefPropertyDefinition"
+      }
     },
     "sites": {
       "description": "Site Definitions",
@@ -167,7 +159,6 @@
     },
     "use_min_spacing": {
       "description": "\"Use Min Spacing\" Option",
-      "writeOnly": true,
       "anyOf": [
         {
           "$ref": "#/definitions/LefOnOff"
@@ -271,6 +262,25 @@
           "type": "string",
           "enum": [
             "Soft"
+          ]
+        }
+      ]
+    },
+    "LefClearanceStyle": {
+      "description": "Clearance Measure Spacing Styles",
+      "oneOf": [
+        {
+          "description": "MAXXY",
+          "type": "string",
+          "enum": [
+            "MaxXY"
+          ]
+        },
+        {
+          "description": "EUCLIDEAN",
+          "type": "string",
+          "enum": [
+            "Euclidean"
           ]
         }
       ]
@@ -409,6 +419,23 @@
           ]
         }
       ]
+    },
+    "LefExtension": {
+      "type": "object",
+      "required": [
+        "data",
+        "name"
+      ],
+      "properties": {
+        "data": {
+          "description": "Stringified data contained in the extension",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the extension",
+          "type": "string"
+        }
+      }
     },
     "LefForeign": {
       "title": "Lef Foreign Cell Declaration",
@@ -663,16 +690,11 @@
           }
         },
         "properties": {
-          "description": "Properties (Unsupported)",
-          "writeOnly": true,
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Unsupported"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "description": "Properties",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LefProperty"
+          }
         },
         "site": {
           "description": "Site Name Note the optional `SITEPATTERN` is not supported",
@@ -1058,16 +1080,11 @@
           }
         },
         "properties": {
-          "description": "Properties (Unsupported)",
-          "writeOnly": true,
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Unsupported"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "description": "Properties",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LefProperty"
+          }
         },
         "shape": {
           "description": "Shape",
@@ -1300,6 +1317,205 @@
           ]
         }
       ]
+    },
+    "LefProperty": {
+      "title": "User Defined Property Instantiation",
+      "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "LefPropertyDefinition": {
+      "title": "User Defined Property Definition",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "LefString"
+          ],
+          "properties": {
+            "LefString": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/LefPropertyDefinitionObjectType"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "LefReal"
+          ],
+          "properties": {
+            "LefReal": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/LefPropertyDefinitionObjectType"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/LefPropertyRange"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 4,
+              "minItems": 4
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "LefInteger"
+          ],
+          "properties": {
+            "LefInteger": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/LefPropertyDefinitionObjectType"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/LefPropertyRange"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 4,
+              "minItems": 4
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "LefPropertyDefinitionObjectType": {
+      "description": "Valid object types for [LefPropertyDefinition]",
+      "oneOf": [
+        {
+          "description": "LAYER",
+          "type": "string",
+          "enum": [
+            "Layer"
+          ]
+        },
+        {
+          "description": "LIBRARY",
+          "type": "string",
+          "enum": [
+            "Library"
+          ]
+        },
+        {
+          "description": "MACRO",
+          "type": "string",
+          "enum": [
+            "Macro"
+          ]
+        },
+        {
+          "description": "NONDEFAULTRULE",
+          "type": "string",
+          "enum": [
+            "NonDefaultRule"
+          ]
+        },
+        {
+          "description": "PIN",
+          "type": "string",
+          "enum": [
+            "Pin"
+          ]
+        },
+        {
+          "description": "VIA",
+          "type": "string",
+          "enum": [
+            "Via"
+          ]
+        },
+        {
+          "description": "VIARULE",
+          "type": "string",
+          "enum": [
+            "ViaRule"
+          ]
+        }
+      ]
+    },
+    "LefPropertyRange": {
+      "title": "Numeric Range for [LefPropertyDefinition]",
+      "type": "object",
+      "required": [
+        "begin",
+        "end"
+      ],
+      "properties": {
+        "begin": {
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "end": {
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        }
+      }
     },
     "LefShape": {
       "title": "Lef Shape Enumeration",

--- a/lef21/src/data.rs
+++ b/lef21/src/data.rs
@@ -77,32 +77,37 @@ pub struct LefLibrary {
     #[builder(default, setter(strip_option))]
     pub units: Option<LefUnits>,
 
+    // Fixed-Mask attribute
+    #[serde(default, skip_serializing)]
+    #[builder(default)]
+    pub fixed_mask: bool,
+
+    /// Clearance Measure
+    #[serde(default, skip_serializing)]
+    #[builder(default)]
+    pub clearance_measure: Option<LefClearanceStyle>,
+    
     // Unsupported fields recommended for *either* LEF "cell libraries" or "technologies"
     /// Via Definitions (Unsupported)
     #[serde(default, skip_serializing)]
     #[builder(default)]
     pub vias: Option<Unsupported>,
-    /// Syntax Extensions (Unsupported)
+    /// Syntax Extensions
     #[serde(default, skip_serializing)]
     #[builder(default)]
-    pub extensions: Option<Unsupported>,
+    pub extensions: Vec<LefExtension>,
     // Fields recommended for LEF technology descriptions, AKA "tech-lefs"
     /// Manufacturing Grid
     #[serde(default, skip_serializing)]
     #[builder(default)]
-    pub manufacturing_grid: Option<Unsupported>,
+    pub manufacturing_grid: Option<LefDecimal>,
     /// "Use Min Spacing" Option
     #[serde(default, skip_serializing)]
     #[builder(default)]
     pub use_min_spacing: Option<LefOnOff>,
-    /// Clearance Measure
-    #[serde(default, skip_serializing)]
-    #[builder(default)]
-    pub clearance_measure: Option<Unsupported>,
     /// Property Definitions
-    #[serde(default, skip_serializing)]
-    #[builder(default)]
-    pub property_definitions: Option<Unsupported>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub property_definitions: Vec<LefPropertyDefinition>,
     /// Layer Definitions
     #[serde(default, skip_serializing)]
     #[builder(default)]
@@ -250,6 +255,15 @@ pub struct LefForeign {
     pub pt: Option<LefPoint>,
     /// Orientation
     pub orient: Option<LefOrient>,
+}
+
+// Customized Syntax Extension
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct LefExtension {
+    /// Name of the extension
+    pub name: String,
+    /// Stringified data contained in the extension
+    pub data: String,
 }
 /// # Lef Pin Definition
 ///
@@ -409,6 +423,15 @@ pub struct LefVia {
 pub enum LefLayerSpacing {
     Spacing(LefDecimal),
     DesignRuleWidth(LefDecimal),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub enum LefPropertyDefinition {
+    LefString(String, Option<String>),
+    LefReal(String, Option<LefDecimal>),
+    LefInteger(String, Option<LefDecimal>),
+    LefRealRange(String, Option<LefDecimal>, LefDecimal, LefDecimal),
+    LefIntegerRange(String, Option<LefDecimal>, LefDecimal, LefDecimal),
 }
 /// # Lef Geometric Object Enumeration
 /// Includes [LefShape]s and Iterators thereof
@@ -634,6 +657,7 @@ enumstr!(
         BusBitChars: "BUSBITCHARS",
         DividerChar: "DIVIDERCHAR",
         BeginExtension: "BEGINEXT",
+        EndExtension: "ENDEXT",
         Tristate: "TRISTATE",
         Input: "INPUT",
         Output: "OUTPUT",
@@ -679,6 +703,13 @@ enumstr!(
         AntennaMaxSideAreaCar: "ANTENNAMAXSIDEAREACAR",
         AntennaMaxCutCar: "ANTENNAMAXCUTCAR",
 
+        // PropertyDefinitions
+        PropertyDefinitions: "PROPERTYDEFINITIONS",
+        String: "STRING",
+        Real: "REAL",
+        Range: "RANGE",
+        Integer: "INTEGER",
+
         // Unsupported
         TaperRule: "TAPERRULE",
         NetExpr: "NETEXPR",
@@ -688,7 +719,6 @@ enumstr!(
         Property: "PROPERTY",
         ManufacturingGrid: "MANUFACTURINGGRID",
         ClearanceMeasure: "CLEARANCEMEASURE",
-        PropertyDefinitions: "PROPERTYDEFINITIONS",
         MaxViaStack: "MAXVIASTACK",
         ViaRule: "VIARULE",
         Generate: "GENERATE",
@@ -706,6 +736,13 @@ enumstr!(
     LefOnOff {
         On: "ON",
         Off: "OFF",
+    }
+);
+enumstr!(
+    /// Clearance Measure Spacing Styles
+    LefClearanceStyle {
+        MaxXY: "MAXXY",
+        Euclidean: "EUCLIDEAN",
     }
 );
 enumstr!(

--- a/lef21/src/data.rs
+++ b/lef21/src/data.rs
@@ -213,15 +213,16 @@ pub struct LefMacro {
     #[builder(default)]
     pub fixed_mask: bool,
 
+    /// Properties
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub properties: Vec<LefProperty>,
+
     // Unsupported
     /// Density Objects (Unsupported)
     #[serde(default, skip_serializing)]
     #[builder(default)]
     pub density: Option<Unsupported>,
-    /// Properties (Unsupported)
-    #[serde(default, skip_serializing)]
-    #[builder(default)]
-    pub properties: Option<Unsupported>,
 }
 impl LefMacro {
     /// Create a new and initially empty [LefMacro] with name `name`
@@ -321,11 +322,11 @@ pub struct LefPin {
     #[builder(default, setter(strip_option))]
     pub net_expr: Option<String>,
 
-    // Unsupported
-    /// Properties (Unsupported)
-    #[serde(default, skip_serializing)]
+    /// Properties
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
-    pub properties: Option<Unsupported>,
+    pub properties: Vec<LefProperty>,
+
 }
 /// # Lef Pin Direction
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
@@ -426,12 +427,22 @@ pub enum LefLayerSpacing {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct LefProperty {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct LefPropertyRange {
+    pub begin: LefDecimal,
+    pub end: LefDecimal,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 pub enum LefPropertyDefinition {
     LefString(String, Option<String>),
-    LefReal(String, Option<LefDecimal>),
-    LefInteger(String, Option<LefDecimal>),
-    LefRealRange(String, Option<LefDecimal>, LefDecimal, LefDecimal),
-    LefIntegerRange(String, Option<LefDecimal>, LefDecimal, LefDecimal),
+    LefReal(String, Option<LefDecimal>, Option<LefPropertyRange>),
+    LefInteger(String, Option<LefDecimal>, Option<LefPropertyRange>),
 }
 /// # Lef Geometric Object Enumeration
 /// Includes [LefShape]s and Iterators thereof

--- a/lef21/src/data.rs
+++ b/lef21/src/data.rs
@@ -440,9 +440,9 @@ pub struct LefPropertyRange {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 pub enum LefPropertyDefinition {
-    LefString(String, Option<String>),
-    LefReal(String, Option<LefDecimal>, Option<LefPropertyRange>),
-    LefInteger(String, Option<LefDecimal>, Option<LefPropertyRange>),
+    LefString(LefKey, String, Option<String>),
+    LefReal(LefKey, String, Option<LefDecimal>, Option<LefPropertyRange>),
+    LefInteger(LefKey, String, Option<LefDecimal>, Option<LefPropertyRange>),
 }
 /// # Lef Geometric Object Enumeration
 /// Includes [LefShape]s and Iterators thereof

--- a/lef21/src/data.rs
+++ b/lef21/src/data.rs
@@ -83,26 +83,26 @@ pub struct LefLibrary {
     pub fixed_mask: bool,
 
     /// Clearance Measure
-    #[serde(default, skip_serializing)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub clearance_measure: Option<LefClearanceStyle>,
-    
+
     // Unsupported fields recommended for *either* LEF "cell libraries" or "technologies"
     /// Via Definitions (Unsupported)
     #[serde(default, skip_serializing)]
     #[builder(default)]
     pub vias: Option<Unsupported>,
     /// Syntax Extensions
-    #[serde(default, skip_serializing)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
     pub extensions: Vec<LefExtension>,
     // Fields recommended for LEF technology descriptions, AKA "tech-lefs"
     /// Manufacturing Grid
-    #[serde(default, skip_serializing)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub manufacturing_grid: Option<LefDecimal>,
     /// "Use Min Spacing" Option
-    #[serde(default, skip_serializing)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub use_min_spacing: Option<LefOnOff>,
     /// Property Definitions
@@ -426,23 +426,26 @@ pub enum LefLayerSpacing {
     DesignRuleWidth(LefDecimal),
 }
 
+/// # User Defined Property Instantiation
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 pub struct LefProperty {
     pub name: String,
     pub value: String,
 }
 
+/// # Numeric Range for [LefPropertyDefinition]
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 pub struct LefPropertyRange {
     pub begin: LefDecimal,
     pub end: LefDecimal,
 }
 
+/// # User Defined Property Definition
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 pub enum LefPropertyDefinition {
-    LefString(LefKey, String, Option<String>),
-    LefReal(LefKey, String, Option<LefDecimal>, Option<LefPropertyRange>),
-    LefInteger(LefKey, String, Option<LefDecimal>, Option<LefPropertyRange>),
+    LefString(LefPropertyDefinitionObjectType, String, Option<String>),
+    LefReal(LefPropertyDefinitionObjectType, String, Option<LefDecimal>, Option<LefPropertyRange>),
+    LefInteger(LefPropertyDefinitionObjectType, String, Option<LefDecimal>, Option<LefPropertyRange>),
 }
 /// # Lef Geometric Object Enumeration
 /// Includes [LefShape]s and Iterators thereof
@@ -682,6 +685,14 @@ enumstr!(
         FixedMask: "FIXEDMASK",
         Mask: "MASK",
         UseMinSpacing: "USEMINSPACING",
+        TaperRule: "TAPERRULE",
+        NetExpr: "NETEXPR",
+        SupplySensitivity: "SUPPLYSENSITIVITY",
+        GroundSensitivity: "GROUNDSENSITIVITY",
+        MustJoin: "MUSTJOIN",
+        Property: "PROPERTY",
+        ManufacturingGrid: "MANUFACTURINGGRID",
+        ClearanceMeasure: "CLEARANCEMEASURE",
 
         // UNITS Fields
         Units: "UNITS",
@@ -722,14 +733,6 @@ enumstr!(
         Integer: "INTEGER",
 
         // Unsupported
-        TaperRule: "TAPERRULE",
-        NetExpr: "NETEXPR",
-        SupplySensitivity: "SUPPLYSENSITIVITY",
-        GroundSensitivity: "GROUNDSENSITIVITY",
-        MustJoin: "MUSTJOIN",
-        Property: "PROPERTY",
-        ManufacturingGrid: "MANUFACTURINGGRID",
-        ClearanceMeasure: "CLEARANCEMEASURE",
         MaxViaStack: "MAXVIASTACK",
         ViaRule: "VIARULE",
         Generate: "GENERATE",
@@ -888,7 +891,18 @@ enumstr!(
         Oxide4: "OXIDE4",
     }
 );
-
+enumstr!(
+    /// Valid object types for [LefPropertyDefinition]
+    LefPropertyDefinitionObjectType {
+        Layer: "LAYER",
+        Library: "LIBRARY",
+        Macro: "MACRO",
+        NonDefaultRule: "NONDEFAULTRULE",
+        Pin: "PIN",
+        Via: "VIA",
+        ViaRule: "VIARULE",
+    }
+);
 use super::read::{LefParseErrorType, ParserState};
 
 /// # Lef Error Enumeration

--- a/lef21/src/read.rs
+++ b/lef21/src/read.rs
@@ -1045,7 +1045,7 @@ impl<'src> LefParser<'src> {
         loop {
             match self.peek_key()? {
                 Layer | Library | Macro | NonDefaultRule | Pin | Via | ViaRule => {
-                    let objtype = self.get_key()?;
+                    let objtype = self.parse_enum::<LefPropertyDefinitionObjectType>()?;
                     let propname = String::from(self.get_name()?); 
                     match self.get_key()? {
                         LefKey::String => {

--- a/lef21/src/write.rs
+++ b/lef21/src/write.rs
@@ -120,6 +120,10 @@ impl<'wr> LefWriter<'wr> {
             self.write_macro(mac)?;
         }
 
+        for ext in lib.extensions.iter() {
+            use LefKey::{BeginExtension, EndExtension};
+            self.write_line(format_args_f!("{BeginExtension} {ext.name} {ext.data} {EndExtension}"))?;
+        }
         // EXTENSIONS would be written here
         // if let Some(ref v) = lib.extensions { }
 
@@ -203,15 +207,23 @@ impl<'wr> LefWriter<'wr> {
             self.indent -= 1;
             self.write_line(format_args_f!("{End} "))?;
         }
-
-        // DENSTITY and PROPERTIES would go here
+        for prop in mac.properties.iter() {
+            self.write_property(prop)?;
+        }
+        // DENSTITY would go here
         // if mac.density.is_some() { }
-        // if mac.properties.is_some() { }
 
         self.indent -= 1;
         self.write_line(format_args_f!("{End} {} ", mac.name))?;
         Ok(())
     }
+
+    fn write_property(&mut self, prop: &LefProperty) -> LefResult<()> {
+        use LefKey::Property;
+        self.write_line(format_args_f!("{Property} {} {}", prop.name, prop.value))?;
+        Ok(())
+    }
+
     /// Write a [LefPin] definition
     fn write_pin(&mut self, pin: &LefPin) -> LefResult<()> {
         use LefKey::{AntennaModel, Direction, End, GroundSensitivity, Layer, MustJoin,
@@ -253,7 +265,10 @@ impl<'wr> LefWriter<'wr> {
         if let Some(ref v) = pin.net_expr {
             self.write_line(format_args_f!("{NetExpr} {v} ; "))?;
         }
-        
+        for prop in pin.properties.iter() {
+            self.write_property(prop)?;
+        }
+
         // Most unsupported PINS features *would* go here.
         // if pin.properties.is_some() {
         //     return Err(LefError::Str("Unsupported LefPin Attr".into()));

--- a/lef21/src/write.rs
+++ b/lef21/src/write.rs
@@ -160,7 +160,7 @@ impl<'wr> LefWriter<'wr> {
 
     // helper function to format numeric PROPERTYDEFINITION entries
     //   for "objType propName [RANGE begin end] [value]"
-    fn format_numeric_prop_def(&mut self, objtype: &LefKey, name: &String, key: LefKey, value: &Option<LefDecimal>, range: &Option<LefPropertyRange>) -> LefResult<String> {
+    fn format_numeric_prop_def(&mut self, objtype: &LefPropertyDefinitionObjectType, name: &String, key: LefKey, value: &Option<LefDecimal>, range: &Option<LefPropertyRange>) -> LefResult<String> {
         use LefKey::Range;
         let mut string_list: Vec<String> = Vec::new();
         string_list.push(objtype.to_string());


### PR DESCRIPTION
+ Implementations of 
   + `PROPERTYDEFINITIONS`
   + `PROPERTY` (on MACRO/PIN)
   + `FIXEDMASK`
   + `CLEARANCEMEASURE`
   + `MANUFACTURINGGRID`
   + Syntax extensions (`BEGINEXT` &rarr; `ENDEXT`)
+ Writing LEF for all `UNITS`

