### PR TITLE
Support reading/writing LEF via definitions

### DIFF
--- a/lef21/resources/lef21.schema.json
+++ b/lef21/resources/lef21.schema.json
@@ -1047,25 +1047,25 @@
       "title": "Lef Offset",
       "type": "object",
       "required": [
-        "x_bot",
-        "x_top",
-        "y_bot",
-        "y_top"
+        "bot_x",
+        "bot_y",
+        "top_x",
+        "top_y"
       ],
       "properties": {
-        "x_bot": {
+        "bot_x": {
           "type": "string",
           "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
         },
-        "x_top": {
+        "bot_y": {
           "type": "string",
           "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
         },
-        "y_bot": {
+        "top_x": {
           "type": "string",
           "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
         },
-        "y_top": {
+        "top_y": {
           "type": "string",
           "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
         }

--- a/lef21/resources/lef21.schema.json
+++ b/lef21/resources/lef21.schema.json
@@ -210,16 +210,11 @@
       ]
     },
     "vias": {
-      "description": "Via Definitions (Unsupported)",
-      "writeOnly": true,
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Unsupported"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "description": "Via Definitions",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/LefViaDef"
+      }
     }
   },
   "definitions": {
@@ -459,6 +454,27 @@
         }
       ]
     },
+    "LefFixedViaDef": {
+      "title": "Lef Fixed Via Definition",
+      "type": "object",
+      "properties": {
+        "layers": {
+          "description": "Layers & Geometries",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LefViaLayerGeometries"
+          }
+        },
+        "resistance_ohms": {
+          "description": "Resistance of the via.\n\nUsing this field is not recommended.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        }
+      }
+    },
     "LefForeign": {
       "title": "Lef Foreign Cell Declaration",
       "description": "Declares the linkage to another cell, commonly in DEF or GDSII format. Foreign-cell references are stored exacty as in the LEF format: as a string cell-name.",
@@ -492,6 +508,126 @@
               "type": "null"
             }
           ]
+        }
+      }
+    },
+    "LefGeneratedViaDef": {
+      "title": "Lef Generated Via Definition",
+      "type": "object",
+      "required": [
+        "bot_enc_x",
+        "bot_enc_y",
+        "bot_metal_layer",
+        "cut_layer",
+        "cut_size_x",
+        "cut_size_y",
+        "cut_spacing_x",
+        "cut_spacing_y",
+        "top_enc_x",
+        "top_enc_y",
+        "top_metal_layer",
+        "via_rule_name"
+      ],
+      "properties": {
+        "bot_enc_x": {
+          "description": "Horizontal enclosure of vias by bottom metal layer.",
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "bot_enc_y": {
+          "description": "Vertical enclosure of vias by bottom metal layer.",
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "bot_metal_layer": {
+          "description": "The bottom metal layer.",
+          "type": "string"
+        },
+        "cut_layer": {
+          "description": "The cut (via) layer.",
+          "type": "string"
+        },
+        "cut_size_x": {
+          "description": "The width of the via rectangles.",
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "cut_size_y": {
+          "description": "The height of the via rectangles.",
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "cut_spacing_x": {
+          "description": "The horizontal spacing (right edge to next left edge) between cuts.",
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "cut_spacing_y": {
+          "description": "The vertical spacing (top edge to bottom edge of cut above) between cuts.",
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "offset": {
+          "description": "Offsets of top and bottom metal layers.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LefOffset"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "origin": {
+          "description": "The origin of the coordinate system specifying all of the via's shapes.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LefPoint"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pattern": {
+          "description": "Specifies a pattern identifying which cuts are missing from the array.\n\nIn the absence of a specified pattern, all cuts are present. This field is currently unsupported.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Unsupported"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rowcol": {
+          "description": "The via array's number of rows and columns.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LefRowCol"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "top_enc_x": {
+          "description": "Horizontal enclosure of vias by top metal layer.",
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "top_enc_y": {
+          "description": "Vertical enclosure of vias by top metal layer.",
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "top_metal_layer": {
+          "description": "The top metal layer.",
+          "type": "string"
+        },
+        "via_rule_name": {
+          "description": "The name of the VIARULE.\n\nMust refer to a previously defined VIARULE GENERATE statement.",
+          "type": "string"
         }
       }
     },
@@ -902,6 +1038,34 @@
       ],
       "properties": {
         "mask": {
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        }
+      }
+    },
+    "LefOffset": {
+      "title": "Lef Offset",
+      "type": "object",
+      "required": [
+        "x_bot",
+        "x_top",
+        "y_bot",
+        "y_top"
+      ],
+      "properties": {
+        "x_bot": {
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "x_top": {
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "y_bot": {
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "y_top": {
           "type": "string",
           "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
         }
@@ -1348,6 +1512,24 @@
         }
       ]
     },
+    "LefRowCol": {
+      "title": "Lef Row and Column",
+      "type": "object",
+      "required": [
+        "cols",
+        "rows"
+      ],
+      "properties": {
+        "cols": {
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        },
+        "rows": {
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+        }
+      }
+    },
     "LefShape": {
       "title": "Lef Shape Enumeration",
       "description": "Includes each of LEF's individual geometric primitives: rectangles, polygons, and paths.",
@@ -1612,6 +1794,166 @@
           "type": "string"
         }
       }
+    },
+    "LefViaDef": {
+      "title": "Lef Via Definition",
+      "description": "LEF supports two kinds of vias: fixed vias and generated vias. Fixed vias contain a set of shapes (rectangles and/or polygons). Generated vias use a VIARULE statement to define via parameters.",
+      "type": "object",
+      "required": [
+        "data",
+        "name"
+      ],
+      "properties": {
+        "data": {
+          "description": "The actual content of the via definition, which may be a fixed via or a generated via.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LefViaDefData"
+            }
+          ]
+        },
+        "default": {
+          "description": "Indicates that this via is a default via for connecting a pair of metal layers.\n\nThe metal layers connected are inferrred from the via's [`LefViaLayerGeometries`], which normally contain geometry on two metal layers and one cut layer.",
+          "default": false,
+          "type": "boolean"
+        },
+        "name": {
+          "description": "The name of the via.",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties (Unsupported)",
+          "writeOnly": true,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Unsupported"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "LefViaDefData": {
+      "title": "Lef Via Definition Data",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Fixed"
+          ],
+          "properties": {
+            "Fixed": {
+              "$ref": "#/definitions/LefFixedViaDef"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Generated"
+          ],
+          "properties": {
+            "Generated": {
+              "$ref": "#/definitions/LefGeneratedViaDef"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "LefViaLayerGeometries": {
+      "title": "Lef Single-Layer Geometry Store for Vias",
+      "description": "[LefViaLayerGeometries] stores the combination of a layer (name) and suite of geometric primitives (rectangles and/or polygons) on that layer.\n\n[LefViaLayerGeometries] are the primary building block of [LefFixedViaDef]s.",
+      "type": "object",
+      "required": [
+        "layer_name"
+      ],
+      "properties": {
+        "layer_name": {
+          "description": "Layer Name",
+          "type": "string"
+        },
+        "shapes": {
+          "description": "Geometries",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LefViaShape"
+          }
+        }
+      }
+    },
+    "LefViaShape": {
+      "title": "Lef Via Shape Enumeration",
+      "description": "These are the geometric primitives that can be included in a via definition.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Rect"
+          ],
+          "properties": {
+            "Rect": {
+              "type": "array",
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/LefMask"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/LefPoint"
+                },
+                {
+                  "$ref": "#/definitions/LefPoint"
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Polygon"
+          ],
+          "properties": {
+            "Polygon": {
+              "type": "array",
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/LefMask"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/LefPoint"
+                  }
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "Unsupported": {
       "title": "Unsupported Feature",

--- a/lef21/resources/lef21.schema.json
+++ b/lef21/resources/lef21.schema.json
@@ -4,7 +4,6 @@
   "description": "LEF's primary design-content container, including a set of macro/cell definitions and associated metadata.",
   "type": "object",
   "required": [
-    "extensions",
     "fixed_mask"
   ],
   "properties": {
@@ -50,8 +49,7 @@
       "minLength": 1
     },
     "extensions": {
-      "description": "Syntax Extensions (Unsupported)",
-      "writeOnly": true,
+      "description": "Syntax Extensions",
       "type": "array",
       "items": {
         "$ref": "#/definitions/LefExtension"

--- a/lef21/src/bin/lefrw.rs
+++ b/lef21/src/bin/lefrw.rs
@@ -1,26 +1,26 @@
-use std::error::Error;
-use std::env;
-use std::process;
 use lef21::LefLibrary;
+use std::env;
+use std::error::Error;
+use std::process;
 
 struct Config {
     inlef: String,
-    outlef: String
+    outlef: String,
 }
 
 impl Config {
-    fn new(args: &[String]) -> Result<Config, &'static str> {    
+    fn new(args: &[String]) -> Result<Config, &'static str> {
         if args.len() < 3 {
-            return Err("Not enough arguments, expecting 2.")
+            return Err("Not enough arguments, expecting 2.");
         }
         let inlef = args[1].clone();
         let outlef = args[2].clone();
-        Ok(Config { inlef, outlef} )
+        Ok(Config { inlef, outlef })
     }
 }
 
 fn run() -> Result<(), Box<dyn Error>> {
-    let args : Vec<String> = env::args().collect();
+    let args: Vec<String> = env::args().collect();
     let cfg = Config::new(&args)?;
     let lib = LefLibrary::open(cfg.inlef)?;
     lib.save(cfg.outlef)?;

--- a/lef21/src/data.rs
+++ b/lef21/src/data.rs
@@ -440,8 +440,6 @@ pub struct LefVia {
 /// LEF supports two kinds of vias: fixed vias and generated vias.
 /// Fixed vias contain a set of shapes (rectangles and/or polygons).
 /// Generated vias use a VIARULE statement to define via parameters.
-///
-/// Generated vias are currently unsupported.
 #[derive(Builder, Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[builder(pattern = "owned", setter(into))]
 pub struct LefViaDef {
@@ -466,7 +464,7 @@ pub struct LefViaDef {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 pub enum LefViaDefData {
     Fixed(LefFixedViaDef),
-    Generated(Unsupported),
+    Generated(LefGeneratedViaDef),
 }
 /// # Lef Fixed Via Definition
 #[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
@@ -482,6 +480,72 @@ pub struct LefFixedViaDef {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
     pub layers: Vec<LefViaLayerGeometries>,
+}
+/// # Lef Generated Via Definition
+#[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[builder(pattern = "owned", setter(into))]
+pub struct LefGeneratedViaDef {
+    /// The name of the VIARULE.
+    ///
+    /// Must refer to a previously defined VIARULE GENERATE statement.
+    pub via_rule_name: String,
+    /// The width of the via rectangles.
+    pub cut_size_x: LefDecimal,
+    /// The height of the via rectangles.
+    pub cut_size_y: LefDecimal,
+    /// The bottom metal layer.
+    pub bot_metal_layer: String,
+    /// The cut (via) layer.
+    pub cut_layer: String,
+    /// The top metal layer.
+    pub top_metal_layer: String,
+    /// The horizontal spacing (right edge to next left edge) between cuts.
+    pub cut_spacing_x: LefDecimal,
+    /// The vertical spacing (top edge to bottom edge of cut above) between cuts.
+    pub cut_spacing_y: LefDecimal,
+    /// Horizontal enclosure of vias by bottom metal layer.
+    pub bot_enc_x: LefDecimal,
+    /// Vertical enclosure of vias by bottom metal layer.
+    pub bot_enc_y: LefDecimal,
+    /// Horizontal enclosure of vias by top metal layer.
+    pub top_enc_x: LefDecimal,
+    /// Vertical enclosure of vias by top metal layer.
+    pub top_enc_y: LefDecimal,
+    /// The via array's number of rows and columns.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub rowcol: Option<LefRowCol>,
+    /// The origin of the coordinate system specifying all of the via's shapes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub origin: Option<LefPoint>,
+    /// Offsets of top and bottom metal layers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub offset: Option<LefOffset>,
+    /// Specifies a pattern identifying which cuts are missing from the array.
+    ///
+    /// In the absence of a specified pattern, all cuts are present.
+    /// This field is currently unsupported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub pattern: Option<Unsupported>,
+}
+/// # Lef Row and Column
+#[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[builder(pattern = "owned", setter(into))]
+pub struct LefRowCol {
+    pub rows: LefDecimal,
+    pub cols: LefDecimal,
+}
+/// # Lef Offset
+#[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[builder(pattern = "owned", setter(into))]
+pub struct LefOffset {
+    pub x_bot: LefDecimal,
+    pub y_bot: LefDecimal,
+    pub x_top: LefDecimal,
+    pub y_top: LefDecimal,
 }
 /// # Lef Single-Layer Geometry Store for Vias
 ///
@@ -792,6 +856,14 @@ enumstr!(
 
         // VIA Fields
         Default: "DEFAULT",
+        ViaRule: "VIARULE",
+        CutSize: "CUTSIZE",
+        Layers: "LAYERS",
+        CutSpacing: "CUTSPACING",
+        Enclosure: "ENCLOSURE",
+        RowCol: "ROWCOL",
+        Offset: "OFFSET",
+        Pattern: "PATTERN",
 
         // Unsupported
         Property: "PROPERTY",
@@ -799,7 +871,6 @@ enumstr!(
         ClearanceMeasure: "CLEARANCEMEASURE",
         PropertyDefinitions: "PROPERTYDEFINITIONS",
         MaxViaStack: "MAXVIASTACK",
-        ViaRule: "VIARULE",
         Generate: "GENERATE",
         NonDefaultRule: "NONDEFAULTRULE",
     }

--- a/lef21/src/data.rs
+++ b/lef21/src/data.rs
@@ -542,10 +542,10 @@ pub struct LefRowCol {
 #[derive(Builder, Clone, Debug, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[builder(pattern = "owned", setter(into))]
 pub struct LefOffset {
-    pub x_bot: LefDecimal,
-    pub y_bot: LefDecimal,
-    pub x_top: LefDecimal,
-    pub y_top: LefDecimal,
+    pub bot_x: LefDecimal,
+    pub bot_y: LefDecimal,
+    pub top_x: LefDecimal,
+    pub top_y: LefDecimal,
 }
 /// # Lef Single-Layer Geometry Store for Vias
 ///

--- a/lef21/src/data.rs
+++ b/lef21/src/data.rs
@@ -80,22 +80,20 @@ pub struct LefLibrary {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub units: Option<LefUnits>,
-
     // Fixed-Mask attribute
     #[serde(default, skip_serializing)]
     #[builder(default)]
     pub fixed_mask: bool,
-
     /// Clearance Measure
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub clearance_measure: Option<LefClearanceStyle>,
-
-    // Unsupported fields recommended for *either* LEF "cell libraries" or "technologies"
-    /// Syntax Extensions (Unsupported)
-    #[serde(default, skip_serializing)]
+    /// Syntax Extensions
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
     pub extensions: Vec<LefExtension>,
+
+    // Unsupported fields recommended for *either* LEF "cell libraries" or "technologies"
     // Fields recommended for LEF technology descriptions, AKA "tech-lefs"
     /// Manufacturing Grid
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/lef21/src/read.rs
+++ b/lef21/src/read.rs
@@ -1234,8 +1234,6 @@ impl<'src> LefParser<'src> {
         Ok((x, y))
     }
     /// Parse a Lef VIA definition
-    ///
-    /// This parser currently only supports fixed vias.
     fn parse_via(&mut self) -> LefResult<LefViaDef> {
         self.ctx.push(LefParseContext::Via);
         self.expect_key(LefKey::Via)?;
@@ -1335,11 +1333,11 @@ impl<'src> LefParser<'src> {
         match self.peek_key()? {
             LefKey::Property => self.fail(LefParseErrorType::Unsupported)?,
             LefKey::End => {
-                self.advance()?; // End of Macro. Eat the END key
+                self.advance()?; // End of Via. Eat the END key
             }
             _ => self.fail(LefParseErrorType::InvalidKey)?,
         }
-        // Parse the END-enclosing macro-name
+        // Parse the END-enclosing via-name
         self.expect_ident(&name)?;
         self.ctx.pop();
         Ok(via.build()?)

--- a/lef21/src/read.rs
+++ b/lef21/src/read.rs
@@ -1298,10 +1298,10 @@ impl<'src> LefParser<'src> {
                     LefKey::Offset => {
                         self.advance()?; // Eat the OFFSET key
                         data = data.offset(LefOffset {
-                            x_bot: self.parse_number()?,
-                            y_bot: self.parse_number()?,
-                            x_top: self.parse_number()?,
-                            y_top: self.parse_number()?,
+                            bot_x: self.parse_number()?,
+                            bot_y: self.parse_number()?,
+                            top_x: self.parse_number()?,
+                            top_y: self.parse_number()?,
                         });
                         self.expect(TokenType::SemiColon)?;
                     }

--- a/lef21/src/read.rs
+++ b/lef21/src/read.rs
@@ -942,12 +942,6 @@ impl<'src> LefParser<'src> {
         layer = layer.layer_name(self.parse_ident()?); // Parse the layer-name
         self.expect(TokenType::SemiColon)?;
 
-        // Now parse the layer-geom body.
-        //
-        // LayerGeometries don't have an END card, so this needs to peek at the next token,
-        // and exit when another LAYER or END (of a higher-level thing) turn up.
-        // Note that on end-of-file, i.e. `peek_token` returning `None`, this will exit and return a valid [LefLayerGeometries].
-        // (Objects above it in the tree may error instead.)
         let mut shapes: Vec<LefViaShape> = Vec::new();
         loop {
             if self.peek_token().is_none() {
@@ -1281,7 +1275,6 @@ impl<'src> LefParser<'src> {
         }
         // Parse the END-enclosing macro-name
         self.expect_ident(&name)?;
-        // Set the pins, build our struct and return it
         self.ctx.pop();
         Ok(via.build()?)
     }

--- a/lef21/src/read.rs
+++ b/lef21/src/read.rs
@@ -1321,6 +1321,7 @@ impl<'src> LefParser<'src> {
             if let LefKey::Resistance = self.peek_key()? {
                 self.advance()?; // Eat the RESISTANCE key
                 data = data.resistance_ohms(self.parse_number()?);
+                self.expect(TokenType::SemiColon)?;
             }
 
             let mut layers = Vec::new();

--- a/lef21/src/tests.rs
+++ b/lef21/src/tests.rs
@@ -145,7 +145,7 @@ fn it_parses_via_lib() -> LefResult<()> {
     VERSION 5.8 ;
     UNITS DATABASE MICRONS 2000 ; END UNITS
     VIA via1 DEFAULT
-      RESISTANCE 21.0
+      RESISTANCE 21.0 ;
       LAYER met1 ;
         RECT MASK 0 -0.5 -0.5 0.5 0.5 ;
       LAYER cut1 ;
@@ -171,9 +171,19 @@ fn it_parses_via_lib() -> LefResult<()> {
       ENCLOSURE 0.1 0.2 0.4 0.2 ;
       ROWCOL 2 3 ;
     END via3
+    VIA via4
+      # comment
+      DEFAULT
+      # another comment
+      RESISTANCE 2.00 ;
+      LAYER met4 ; RECT -1 -1 1 1 ;
+      # yet another comment
+      LAYER via4 ; RECT -0.5 -0.5 0.5 0.5 ;
+      LAYER met5 ; RECT -2 -2 2 2 ;
+    END via4
     "#;
     let lib = parse_str(src)?;
-    assert_eq!(lib.vias.len(), 3);
+    assert_eq!(lib.vias.len(), 4);
     let via2 = &lib.vias[1];
     assert_eq!(
         *via2,

--- a/lef21/src/tests.rs
+++ b/lef21/src/tests.rs
@@ -163,9 +163,17 @@ fn it_parses_via_lib() -> LefResult<()> {
       LAYER met3 ;
         RECT -0.4 -0.4 0.4 0.4 ;
     END via2
+    VIA via3 DEFAULT
+      VIARULE genvia3 ;
+      CUTSIZE 0.2 0.2 ;
+      LAYERS met3 via3 met4 ;
+      CUTSPACING 0.1 0.1 ;
+      ENCLOSURE 0.1 0.2 0.4 0.2 ;
+      ROWCOL 2 3 ;
+    END via3
     "#;
     let lib = parse_str(src)?;
-    assert_eq!(lib.vias.len(), 2);
+    assert_eq!(lib.vias.len(), 3);
     let via2 = &lib.vias[1];
     assert_eq!(
         *via2,
@@ -220,6 +228,36 @@ fn it_parses_via_lib() -> LefResult<()> {
                         )],
                     },
                 ],
+            }),
+            properties: None,
+        }
+    );
+    let via3 = &lib.vias[2];
+    assert_eq!(
+        *via3,
+        LefViaDef {
+            name: "via3".into(),
+            default: true,
+            data: LefViaDefData::Generated(LefGeneratedViaDef {
+                via_rule_name: "genvia3".into(),
+                cut_size_x: Decimal::new(2, 1),
+                cut_size_y: Decimal::new(2, 1),
+                bot_metal_layer: "met3".into(),
+                cut_layer: "via3".into(),
+                top_metal_layer: "met4".into(),
+                cut_spacing_x: Decimal::new(1, 1),
+                cut_spacing_y: Decimal::new(1, 1),
+                bot_enc_x: Decimal::new(1, 1),
+                bot_enc_y: Decimal::new(2, 1),
+                top_enc_x: Decimal::new(4, 1),
+                top_enc_y: Decimal::new(2, 1),
+                rowcol: Some(LefRowCol {
+                    rows: Decimal::new(2, 0),
+                    cols: Decimal::new(3, 0),
+                }),
+                origin: None,
+                offset: None,
+                pattern: None,
             }),
             properties: None,
         }

--- a/lef21/src/write.rs
+++ b/lef21/src/write.rs
@@ -139,6 +139,7 @@ impl<'wr> LefWriter<'wr> {
             self.write_via(via)?;
         }
 
+        // TODO: VIARULE [GENERATE]
         // TODO: NONDEFAULTRULE
 
         // Write each SITE definition

--- a/lef21/src/write.rs
+++ b/lef21/src/write.rs
@@ -130,7 +130,7 @@ impl<'wr> LefWriter<'wr> {
         self.dest.flush()?;
         Ok(())
     }
-    /// Write a [LefViaDef], in recommended order of fields.
+    /// Write a [LefViaDef].
     fn write_via(&mut self, via: &LefViaDef) -> LefResult<()> {
         use LefKey::{Default, End, Resistance, Via};
 
@@ -348,7 +348,7 @@ impl<'wr> LefWriter<'wr> {
         self.indent -= 1;
         Ok(()) // Note [LefLayerGeometries] have no "END" or other closing delimeter.
     }
-    /// Write the [LefLayerGeometries], common to both ports and obstructions
+    /// Write [LefViaLayerGeometries].
     fn write_via_layer_geom(&mut self, layer: &LefViaLayerGeometries) -> LefResult<()> {
         use LefKey::Layer;
         self.write_line(format_args_f!("{Layer} {layer.layer_name} ;"))?;
@@ -358,8 +358,9 @@ impl<'wr> LefWriter<'wr> {
             self.write_via_shape(shape)?;
         }
         self.indent -= 1;
-        Ok(()) // Note [LefLayerGeometries] have no "END" or other closing delimeter.
+        Ok(()) // No END token.
     }
+    /// Writes a [`LefViaShape`].
     fn write_via_shape(&mut self, shape: &LefViaShape) -> LefResult<()> {
         use LefKey::{Polygon, Rect};
         match shape {

--- a/lef21/src/write.rs
+++ b/lef21/src/write.rs
@@ -108,8 +108,7 @@ impl<'wr> LefWriter<'wr> {
             self.write_line(format_args_f!("{End} {Units} "))?;
         }
 
-        // VIAS would be written here
-        // if let Some(ref v) = lib.vias { }
+        // Write each via definition
         for via in lib.vias.iter() {
             self.write_via(via)?;
         }


### PR DESCRIPTION
Adds support for VIA definitions as described in the LEF 5.8/6.0 specification:
- "Fixed" vias (ie. those with an explicitly listed set of shapes)
- "Generated" vias (ie. those described by a VIARULE)

Note that although we support parsing both kinds of vias, we don't yet support parsing VIARULE GENERATE statements (which generated vias reference).