### PR TITLE
fix read_str when str is empty

### DIFF
--- a/gds21/src/read.rs
+++ b/gds21/src/read.rs
@@ -191,6 +191,9 @@ where
         self.source.read_exact(data)?;
         // Strip optional end-of-string chars
         let len = data.len();
+        if len == 0 {
+            return Ok("".to_string());
+        }
         if data[len - 1] == 0x00 {
             data = &mut data[0..len - 1];
         }


### PR DESCRIPTION
I found that for some GDS files a string can be empty causing an usize underflow in the read_str method.

This fixes it.